### PR TITLE
Add Default instances for 6- and 7-tuples

### DIFF
--- a/Data/Default.hs
+++ b/Data/Default.hs
@@ -101,5 +101,7 @@ instance (Default a, Default b) => Default (a, b) where def = (def, def)
 instance (Default a, Default b, Default c) => Default (a, b, c) where def = (def, def, def)
 instance (Default a, Default b, Default c, Default d) => Default (a, b, c, d) where def = (def, def, def, def)
 instance (Default a, Default b, Default c, Default d, Default e) => Default (a, b, c, d, e) where def = (def, def, def, def, def)
+instance (Default a, Default b, Default c, Default d, Default e, Default f) => Default (a, b, c, d, e, f) where def = (def, def, def, def, def, def)
+instance (Default a, Default b, Default c, Default d, Default e, Default f, Default g) => Default (a, b, c, d, e, f, g) where def = (def, def, def, def, def, def, def)
 
 instance Default TimeLocale where def = defaultTimeLocale


### PR DESCRIPTION
This seems a bit silly but an instance for 6-tuples would be kind of useful for an app I'm working on, it would at least allow me throw away a `newtype`. I also added an instance for 7-tuples since many `base` functions and classes seem to go up to 7 (e.g. `zipWith7`, `Data.Data`).
