### PR TITLE
Added default Signatures using Generics

### DIFF
--- a/data-default.cabal
+++ b/data-default.cabal
@@ -1,5 +1,5 @@
 Name:            data-default
-Version:         0.5.1
+Version:         0.5.2
 Cabal-Version:   >= 1.6
 Category:        Data
 Synopsis:        A class for types with a default value
@@ -14,6 +14,6 @@ source-repository head
   location: https://github.com/mauke/data-default
 
 Library
-  Build-Depends:     base >=2 && <5, containers, dlist, old-locale
+  Build-Depends:     base >=2 && <5, containers, dlist, old-locale, ghc-prim
   Exposed-Modules:   Data.Default
   Ghc-Options:       -Wall -O2


### PR DESCRIPTION
Followup to the old email I sent.

Now Default instances can be created like Aeson instances

```
$ ghci -XDeriveGeneric Data/Default.hs  
>>> import GHC.Generics
>>> data Foo = Bar | Baz | Quux deriving(Show, Generic)
>>> instance Default Foo
>>> def :: Foo
Bar
```

If you are worried about backward compatibility pre 7.4 I can add the #defines and cabal flags necessary for conditional builds. 

Best,
Jonathan
