### PR TITLE
Add Generics support

### DIFF
--- a/data-default-class/Data/Default/Class.hs
+++ b/data-default-class/Data/Default/Class.hs
@@ -29,12 +29,44 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -}
 
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE DefaultSignatures, TypeOperators, FlexibleContexts #-}
+#endif
+
 module Data.Default.Class (
 -- | This module defines a class for types with a default value.
     Default(..)
 ) where
 
+#if __GLASGOW_HASKELL__ >= 706
+import GHC.Generics
+#endif
+
 -- | A class for types with a default value.
 class Default a where
     -- | The default value for this type.
     def :: a
+
+#if __GLASGOW_HASKELL__ >= 706
+    default def :: (Generic a, GDefault (Rep a)) => a
+    def = to gdef
+#endif
+
+#if __GLASGOW_HASKELL__ >= 706
+
+class GDefault f where
+    gdef :: f a
+
+instance GDefault U1 where
+    gdef = U1
+
+instance (Default a) => GDefault (K1 i a) where
+    gdef = K1 def
+
+instance (GDefault a, GDefault b) => GDefault (a :*: b) where
+    gdef = gdef :*: gdef
+
+instance (GDefault a) => GDefault (M1 i c a) where
+    gdef = M1 gdef
+
+#endif

--- a/data-default-class/data-default-class.cabal
+++ b/data-default-class/data-default-class.cabal
@@ -16,3 +16,4 @@ source-repository head
 Library
   Build-Depends:     base >=2 && <5
   Exposed-Modules:   Data.Default.Class
+  Extensions:        CPP


### PR DESCRIPTION
This adds support for Generics, allowing one to derive `Default` automagically if using recent enough GHC. This is primarily useful when declaring `Default` for big records (think database rows, these also often do already have a Generic instance to e.g. derive `aeson`s classes), going especially nice with DeriveAnyClass in GHC 7.10. I've tried to make it is as semantically correct as possible (i.e. not defined it for sum types, as we can't know which one we should use).
The support is made conditional using CPP, so users with other compilers than GHC (or old GHC versions) won't be affected. I've taken GHC 7.6.1 as a lower bound because then we skip depending on anything other than `base`. Overall this should be zero-impact for all users, while adding Generics support for those who need it.