### PR TITLE
Fix missing GHC.Generics support for GHC 7.4 (re #13)

### DIFF
--- a/data-default-class/Data/Default/Class.hs
+++ b/data-default-class/Data/Default/Class.hs
@@ -31,13 +31,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 {-# LANGUAGE CPP #-}
 
-#if __GLASGOW_HASKELL__ >= 706
-#define HAVE_GHC_706 1
-#else
-#define HAVE_GHC_706 0
-#endif
+#define HAVE_GHC_GENERICS (__GLASGOW_HASKELL__ >= 704)
 
-#if HAVE_GHC_706
+#if HAVE_GHC_GENERICS
 {-# LANGUAGE DefaultSignatures, TypeOperators, FlexibleContexts #-}
 #endif
 
@@ -46,7 +42,7 @@ module Data.Default.Class (
     Default(..)
 ) where
 
-#if HAVE_GHC_706
+#if HAVE_GHC_GENERICS
 import GHC.Generics
 
 class GDefault f where
@@ -70,7 +66,7 @@ class Default a where
     -- | The default value for this type.
     def :: a
 
-#if HAVE_GHC_706
+#if HAVE_GHC_GENERICS
     default def :: (Generic a, GDefault (Rep a)) => a
     def = to gdef
 #endif

--- a/data-default-class/data-default-class.cabal
+++ b/data-default-class/data-default-class.cabal
@@ -1,6 +1,6 @@
 Name:            data-default-class
-Version:         0.1.0
-Cabal-Version:   >= 1.6
+Version:         0.1.0.1
+Cabal-Version:   >= 1.06
 Category:        Data
 Synopsis:        A class for types with a default value
 Build-Type:      Simple
@@ -15,4 +15,10 @@ source-repository head
 
 Library
   Build-Depends:     base >=2 && <5
+  if impl(ghc == 7.4.*)
+      -- this package provide GHC.Generics support for all GHC
+      -- versions (i.e. starting with GHC 7.4) which support Generics.
+      -- For GHC 7.4 only, however, "GHC.Generics" is provided by
+      -- `ghc-prim` rather than `base`
+      build-depends: ghc-prim
   Exposed-Modules:   Data.Default.Class


### PR DESCRIPTION
GHC.Generics support was added via #9 but left out support for
GHC 7.4, thereby resulting in an *observable* conditional API, which in turn
violates the PVP contract and cause problems down the line for packages
depending on `data-default-class` which depend on `Generics` support.

This simple patch adds `Generics`-support for GHC 7.4 and consequently
fixes #13.