### PR TITLE
Generic instance for sum types

### DIFF
--- a/data-default-class/Data/Default/Class.hs
+++ b/data-default-class/Data/Default/Class.hs
@@ -72,6 +72,9 @@ instance (Default a) => GDefault (K1 i a) where
 instance (GDefault a, GDefault b) => GDefault (a :*: b) where
     gdef = gdef :*: gdef
 
+instance (GDefault a) => GDefault (a :+: b) where
+    gdef = L1 gdef
+
 instance (GDefault a) => GDefault (M1 i c a) where
     gdef = M1 gdef
 #endif


### PR DESCRIPTION
Hi great library,

I was using it and somehow I assume this instance did exist, but did not and had to fork it on my project as `GDefault` is not exported and I was using tons of enums. I think other people might assume/need this instance as well. 